### PR TITLE
Fix for #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,7 +590,8 @@ open FsExcel
 open System.Globalization
 
 [
-    Worksheet CultureInfo.CurrentCulture.NativeName
+    let britishCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-GB")
+    Worksheet britishCulture.NativeName
     for m in 1..12 do
         let monthName = CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(m)
         Cell [ String monthName ]
@@ -690,15 +691,16 @@ type JoiningInfo =  {
     Name : string
     Age : int
     Fees : decimal
-    DateJoined : DateTime
+    DateJoined : string
 }
 
 // This works just as well if these are anonymous record instances,
 // eg. {| Name = "..."; ... |}
+// harmless change
 let records = [
-    { Name = "Jane Smith"; Age = 32; Fees = 59.25m; DateJoined = System.DateTime(2022, 3, 12) }
-    { Name = "Michael Nguyễn"; Age = 23; Fees = 61.2m; DateJoined = System.DateTime(2022, 3, 13) }
-    { Name = "Sofia Hernández"; Age = 58; Fees = 59.25m; DateJoined = System.DateTime(2022, 3, 15) }
+    { Name = "Jane Smith"; Age = 32; Fees = 59.25m; DateJoined = "2022-03-12" } // Excel will treat these strings as dates
+    { Name = "Michael Nguyễn"; Age = 23; Fees = 61.2m; DateJoined = "2022-03-13" }
+    { Name = "Sofia Hernández"; Age = 58; Fees = 59.25m; DateJoined = "2022-03-15" }
 ]
 
 let cellStyleVertical index name =

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Nuget](https://img.shields.io/nuget/v/Fsexcel)](https://www.nuget.org/packages/FsExcel/)
 
 
-## Welcome!
+## Welcome! 
 
 Welcome to FsExcel, a library for generating Excel spreadsheets using very simple code.
 
@@ -593,7 +593,7 @@ open System.Globalization
     let britishCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-GB")
     Worksheet britishCulture.NativeName
     for m in 1..12 do
-        let monthName = CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(m)
+        let monthName = britishCulture.DateTimeFormat.GetMonthName(m)
         Cell [ String monthName ]
         Cell [ Integer monthName.Length ]
         Go NewRow

--- a/src/Notebooks/Tutorial.dib
+++ b/src/Notebooks/Tutorial.dib
@@ -638,7 +638,8 @@ open FsExcel
 open System.Globalization
 
 [
-    Worksheet CultureInfo.CurrentCulture.NativeName
+    let britishCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-GB")
+    Worksheet britishCulture.NativeName
     for m in 1..12 do
         let monthName = CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(m)
         Cell [ String monthName ]
@@ -744,15 +745,16 @@ type JoiningInfo =  {
     Name : string
     Age : int
     Fees : decimal
-    DateJoined : DateTime
+    DateJoined : string
 }
 
 // This works just as well if these are anonymous record instances,
 // eg. {| Name = "..."; ... |}
+// harmless change
 let records = [
-    { Name = "Jane Smith"; Age = 32; Fees = 59.25m; DateJoined = System.DateTime(2022, 3, 12) }
-    { Name = "Michael Nguyễn"; Age = 23; Fees = 61.2m; DateJoined = System.DateTime(2022, 3, 13) }
-    { Name = "Sofia Hernández"; Age = 58; Fees = 59.25m; DateJoined = System.DateTime(2022, 3, 15) }
+    { Name = "Jane Smith"; Age = 32; Fees = 59.25m; DateJoined = "2022-03-12" } // Excel will treat these strings as dates
+    { Name = "Michael Nguyễn"; Age = 23; Fees = 61.2m; DateJoined = "2022-03-13" }
+    { Name = "Sofia Hernández"; Age = 58; Fees = 59.25m; DateJoined = "2022-03-15" }
 ]
 
 let cellStyleVertical index name =

--- a/src/Notebooks/Tutorial.dib
+++ b/src/Notebooks/Tutorial.dib
@@ -8,7 +8,7 @@
 [![Nuget](https://img.shields.io/nuget/v/Fsexcel)](https://www.nuget.org/packages/FsExcel/)
 
 
-## Welcome!
+## Welcome! 
 
 Welcome to FsExcel, a library for generating Excel spreadsheets using very simple code.
 
@@ -641,7 +641,7 @@ open System.Globalization
     let britishCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-GB")
     Worksheet britishCulture.NativeName
     for m in 1..12 do
-        let monthName = CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(m)
+        let monthName = britishCulture.DateTimeFormat.GetMonthName(m)
         Cell [ String monthName ]
         Cell [ Integer monthName.Length ]
         Go NewRow

--- a/src/Scripts/CreateRegressionTestActuals.fsx
+++ b/src/Scripts/CreateRegressionTestActuals.fsx
@@ -388,7 +388,8 @@ module Test16 =
     open System.Globalization
     
     [
-        Worksheet CultureInfo.CurrentCulture.NativeName
+        let britishCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-GB")
+        Worksheet britishCulture.NativeName
         for m in 1..12 do
             let monthName = CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(m)
             Cell [ String monthName ]
@@ -448,13 +449,13 @@ module Test18 =
         Name : string
         Age : int
         Fees : decimal
-        DateJoined : DateTime
+        DateJoined : string
     }
     
     let records = [
-        { Name = "Jane Smith"; Age = 32; Fees = 59.25m; DateJoined = System.DateTime(2022, 3, 12) }
-        { Name = "Michael Nguyễn"; Age = 23; Fees = 61.2m; DateJoined = System.DateTime(2022, 3, 13) }
-        { Name = "Sofia Hernández"; Age = 58; Fees = 59.25m; DateJoined = System.DateTime(2022, 3, 15) }
+        { Name = "Jane Smith"; Age = 32; Fees = 59.25m; DateJoined = "2022-03-12" } // Excel will treat these strings as dates
+        { Name = "Michael Nguyễn"; Age = 23; Fees = 61.2m; DateJoined = "2022-03-13" }
+        { Name = "Sofia Hernández"; Age = 58; Fees = 59.25m; DateJoined = "2022-03-15" }
     ]
     
     let cellStyleVertical index name =

--- a/src/Scripts/CreateRegressionTestActuals.fsx
+++ b/src/Scripts/CreateRegressionTestActuals.fsx
@@ -391,7 +391,7 @@ module Test16 =
         let britishCulture = CultureInfo.GetCultureInfoByIetfLanguageTag("en-GB")
         Worksheet britishCulture.NativeName
         for m in 1..12 do
-            let monthName = CultureInfo.CurrentCulture.DateTimeFormat.GetMonthName(m)
+            let monthName = britishCulture.DateTimeFormat.GetMonthName(m)
             Cell [ String monthName ]
             Cell [ Integer monthName.Length ]
             Go NewRow


### PR DESCRIPTION
I encountered two issues with the tests that were caused by variances in system settings between my development setup and the one used to generate the "Expected" workbooks. I made some changes to the tests that I believe are robust to differences in settings. I also wanted to avoid making changes to the "Expected" workbooks and the screenshots included in the tutorial. 

For the worksheets test, I changed the code that named the first sheet so that it is hard-coded to the "en-GB" culture that was used to create the expected value. 

Addressing the "Tables from Types" test was interesting. In the "Actual" spreadsheets the DateJoined field values didn't match because my system's offset from UTC was applied. After experimenting with various changes, I landed on changing the type of the DateJoined field to a string and providing values in the "YYYY-MM-DD" format. Due to the way Excel handles dates, this is a very robust way to specify exact dates in Excel. 