### PR TITLE
Add support for named cells

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,20 @@ open FsExcel
 
 ---
 ## Named cells
+
+To create worksheet scoped name use  
+`
+Name "Username"
+`  
+or  
+`
+ScopedName ("Email", NameScope.Worksheet)
+`  
+
+To create workbook scoped name use  
+`
+ScopedName ("Email", NameScope.Workbook)
+`
 <!-- Test -->
 
 ```fsharp
@@ -594,8 +608,11 @@ open FsExcel
 
 [
     Cell [ 
-        String "Invoice 123"
-        Name ("InvoiceName", NameScope.Worksheet) ]
+        String "JohnDoe"
+        Name "Username" ]
+    Cell [ 
+        String "john.doe@company.com"
+        ScopedName ("Email", NameScope.Workbook) ]
 ]
 |> Render.AsFile (Path.Combine(savePath, "NamedCells.xlsx"))
 

--- a/README.md
+++ b/README.md
@@ -581,6 +581,25 @@ open FsExcel
      style="width: 150px;" />
 
 ---
+## Named cells
+<!-- Test -->
+
+```fsharp
+#r "nuget: FsExcel"
+
+let savePath = "/temp"
+
+open System.IO
+open FsExcel
+
+[
+    Cell [ 
+        String "Invoice 123"
+        Name ("InvoiceName", NameScope.Worksheet) ]
+]
+|> Render.AsFile (Path.Combine(savePath, "NamedCells.xlsx"))
+
+```
 ## Worksheets (Tabs)
 
 By default, all cells are placed into a worksheet (tab) called "Sheet1".  You can override this, and create additional worksheets, using `Worksheet ...`.

--- a/src/FsExcel/FsExcel.fs
+++ b/src/FsExcel/FsExcel.fs
@@ -41,6 +41,10 @@ type HorizontalAlignment =
     | Center
     | Right
 
+type NameScope =
+    | Worksheet
+    | Workbook
+    
 type CellProp =
     | String of string
     | Float of float
@@ -59,6 +63,7 @@ type CellProp =
     | BackgroundColor of XLColor
     | HorizontalAlignment of HorizontalAlignment
     | FormatCode of string
+    | Name of name: string * scope: NameScope
 
 module CellProps = 
 
@@ -257,6 +262,12 @@ module Render =
                             cell.Style.Alignment.Horizontal <- XLAlignmentHorizontalValues.Right
                     | FormatCode fc ->
                         cell.Style.NumberFormat.Format <- fc
+                    | Name (name, scope) ->
+                        let xlScope =
+                            match scope with
+                            | NameScope.Worksheet -> XLScope.Worksheet
+                            | NameScope.Workbook -> XLScope.Workbook
+                        cell.AddToNamed(name, xlScope) |> ignore
             | AutoFit af ->
                 let ws = getCurrentWorksheet()
 

--- a/src/FsExcel/FsExcel.fs
+++ b/src/FsExcel/FsExcel.fs
@@ -63,7 +63,8 @@ type CellProp =
     | BackgroundColor of XLColor
     | HorizontalAlignment of HorizontalAlignment
     | FormatCode of string
-    | Name of name: string * scope: NameScope
+    | Name of string
+    | ScopedName of name: string * scope: NameScope
 
 module CellProps = 
 
@@ -262,7 +263,9 @@ module Render =
                             cell.Style.Alignment.Horizontal <- XLAlignmentHorizontalValues.Right
                     | FormatCode fc ->
                         cell.Style.NumberFormat.Format <- fc
-                    | Name (name, scope) ->
+                    | Name name ->
+                        cell.AddToNamed(name, XLScope.Worksheet) |> ignore
+                    | ScopedName (name, scope) ->
                         let xlScope =
                             match scope with
                             | NameScope.Worksheet -> XLScope.Worksheet

--- a/src/Notebooks/Tutorial.dib
+++ b/src/Notebooks/Tutorial.dib
@@ -629,6 +629,20 @@ open FsExcel
 #!markdown
 
 ## Named cells
+
+To create worksheet scoped name use  
+`
+Name "Username"
+`  
+or  
+`
+ScopedName ("Email", NameScope.Worksheet)
+`  
+
+To create workbook scoped name use  
+`
+ScopedName ("Email", NameScope.Workbook)
+`
 <!-- Test -->
 
 #!fsharp
@@ -642,8 +656,11 @@ open FsExcel
 
 [
     Cell [ 
-        String "Invoice 123"
-        Name ("InvoiceName", NameScope.Worksheet) ]
+        String "JohnDoe"
+        Name "Username" ]
+    Cell [ 
+        String "john.doe@company.com"
+        ScopedName ("Email", NameScope.Workbook) ]
 ]
 |> Render.AsFile (Path.Combine(savePath, "NamedCells.xlsx"))
 

--- a/src/Notebooks/Tutorial.dib
+++ b/src/Notebooks/Tutorial.dib
@@ -628,6 +628,27 @@ open FsExcel
 
 #!markdown
 
+## Named cells
+<!-- Test -->
+
+#!fsharp
+
+#r "nuget: FsExcel"
+
+let savePath = "/temp"
+
+open System.IO
+open FsExcel
+
+[
+    Cell [ 
+        String "Invoice 123"
+        Name ("InvoiceName", NameScope.Worksheet) ]
+]
+|> Render.AsFile (Path.Combine(savePath, "NamedCells.xlsx"))
+
+#!markdown
+
 ## Worksheets (Tabs)
 
 By default, all cells are placed into a worksheet (tab) called "Sheet1".  You can override this, and create additional worksheets, using `Worksheet ...`.


### PR DESCRIPTION
This PR implements #29

The changes in this PR are as follows:
* add support for named cells


To create worksheet scoped name use
```F#
Name "Username"
```  
or
```F#
ScopedName ("Email", NameScope.Worksheet)
```

To create workbook scoped name use
```
ScopedName ("Email", NameScope.Workbook)
```